### PR TITLE
[front] 회원가입 ui 구현

### DIFF
--- a/frontend/composeApp/src/commonMain/kotlin/com/parksupark/paractice/App.kt
+++ b/frontend/composeApp/src/commonMain/kotlin/com/parksupark/paractice/App.kt
@@ -18,7 +18,7 @@ fun App() {
                 navController = navHostController,
                 startDestination = AuthRoute.Root,
             ) {
-                authGraph()
+                authGraph(navController = navHostController)
             }
         }
     }

--- a/frontend/composeApp/src/commonMain/kotlin/com/parksupark/paractice/feature/auth/navigation/AuthNavigation.kt
+++ b/frontend/composeApp/src/commonMain/kotlin/com/parksupark/paractice/feature/auth/navigation/AuthNavigation.kt
@@ -1,30 +1,48 @@
 package com.parksupark.paractice.feature.auth.navigation
 
 import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavHostController
+import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
 import androidx.navigation.navigation
 import com.parksupark.paractice.feature.auth.presentation.login.LoginRoute
+import com.parksupark.paractice.feature.auth.presentation.signup.SignupRoute
 import kotlinx.serialization.Serializable
 
 @Serializable
-sealed class AuthRoute {
+sealed interface AuthRoute {
     @Serializable
-    data object Root : AuthRoute()
+    data object Root : AuthRoute
 
     @Serializable
-    data object Login : AuthRoute()
+    data object Login : AuthRoute
+
+    @Serializable
+    data object SignUp : AuthRoute
 }
 
-fun NavGraphBuilder.authGraph() {
+fun NavGraphBuilder.authGraph(navController: NavHostController) {
     navigation<AuthRoute.Root>(
         startDestination = AuthRoute.Login,
     ) {
         composable<AuthRoute.Login> {
             LoginRoute(
                 navigateToHome = { /* TODO */ },
-                navigateToSignup = { /* TODO */ },
+                navigateToSignup = navController::navigateToSignup,
                 navigateToForgotPassword = { /* TODO */ },
             )
         }
+        composable<AuthRoute.SignUp> {
+            SignupRoute(
+                navigateUp = navController::navigateUp,
+            )
+        }
     }
+}
+
+private fun NavHostController.navigateToSignup(navOptions: NavOptions? = null) {
+    navigate(
+        route = AuthRoute.SignUp,
+        navOptions = navOptions,
+    )
 }

--- a/frontend/composeApp/src/commonMain/kotlin/com/parksupark/paractice/feature/auth/presentation/components/AuthButtons.kt
+++ b/frontend/composeApp/src/commonMain/kotlin/com/parksupark/paractice/feature/auth/presentation/components/AuthButtons.kt
@@ -1,4 +1,4 @@
-package com.parksupark.paractice.feature.auth.presentation.login.components
+package com.parksupark.paractice.feature.auth.presentation.components
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -35,26 +35,6 @@ fun ForgotPasswordButton(
 }
 
 @Composable
-fun LoginButton(
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    Button(
-        onClick = onClick,
-        modifier = modifier
-            .fillMaxWidth()
-            .padding(horizontal = 16.dp),
-        shape = MaterialTheme.shapes.small,
-    ) {
-        Text(
-            text = "Login",
-            modifier = Modifier.padding(vertical = 8.dp),
-            style = MaterialTheme.typography.labelLarge,
-        )
-    }
-}
-
-@Composable
 fun SignUpButton(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
@@ -82,6 +62,26 @@ fun SignUpButton(
 }
 
 @Composable
+fun AuthButton(
+    text: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Button(
+        onClick = onClick,
+        modifier = modifier
+            .padding(horizontal = 16.dp),
+        shape = MaterialTheme.shapes.small,
+    ) {
+        Text(
+            text = text,
+            modifier = Modifier.padding(vertical = 8.dp),
+            style = MaterialTheme.typography.labelLarge,
+        )
+    }
+}
+
+@Composable
 @Preview
 private fun LoginButtonsPreview() {
     PTheme {
@@ -89,10 +89,11 @@ private fun LoginButtonsPreview() {
             ForgotPasswordButton(
                 onClick = { },
             )
-            LoginButton(
+            SignUpButton(
                 onClick = { },
             )
-            SignUpButton(
+            AuthButton(
+                text = "Login",
                 onClick = { },
             )
         }

--- a/frontend/composeApp/src/commonMain/kotlin/com/parksupark/paractice/feature/auth/presentation/components/AuthTextFields.kt
+++ b/frontend/composeApp/src/commonMain/kotlin/com/parksupark/paractice/feature/auth/presentation/components/AuthTextFields.kt
@@ -1,4 +1,4 @@
-package com.parksupark.paractice.feature.auth.presentation.login.components
+package com.parksupark.paractice.feature.auth.presentation.components
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -44,7 +44,7 @@ fun EmailTextField(
     onKeyboardAction: KeyboardActionHandler,
     modifier: Modifier = Modifier,
 ) {
-    LoginTextField(
+    AuthTextField(
         state = state,
         startIcon = Icons.Outlined.Email,
         hint = "Email",
@@ -63,7 +63,7 @@ fun PasswordTextField(
     onKeyboardAction: KeyboardActionHandler,
     modifier: Modifier = Modifier,
 ) {
-    LoginTextField(
+    AuthTextField(
         state = state,
         startIcon = Icons.Outlined.Key,
         hint = "Password",
@@ -78,7 +78,7 @@ fun PasswordTextField(
 }
 
 @Composable
-private fun LoginTextField(
+private fun AuthTextField(
     state: TextFieldState,
     startIcon: ImageVector,
     hint: String,
@@ -157,7 +157,7 @@ private fun LoginTextField(
 
 @Composable
 @Preview
-private fun LoginTextFieldPreview() {
+private fun AuthTextFieldPreview() {
     PTheme {
         Column {
             EmailTextField(

--- a/frontend/composeApp/src/commonMain/kotlin/com/parksupark/paractice/feature/auth/presentation/components/AuthTextFields.kt
+++ b/frontend/composeApp/src/commonMain/kotlin/com/parksupark/paractice/feature/auth/presentation/components/AuthTextFields.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Email
 import androidx.compose.material.icons.outlined.Key
+import androidx.compose.material.icons.outlined.Person
 import androidx.compose.material3.Icon
 import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.MaterialTheme
@@ -39,20 +40,35 @@ import com.parksupark.paractice.core.designsystem.PTheme
 import org.jetbrains.compose.ui.tooling.preview.Preview
 
 @Composable
+fun UsernameTextField(
+    state: TextFieldState,
+    modifier: Modifier = Modifier,
+    keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
+    onKeyboardAction: KeyboardActionHandler? = null,
+) {
+    AuthTextField(
+        state = state,
+        startIcon = Icons.Outlined.Person,
+        hint = "Username",
+        modifier = modifier,
+        keyboardOptions = keyboardOptions,
+        onKeyboardAction = onKeyboardAction,
+    )
+}
+
+@Composable
 fun EmailTextField(
     state: TextFieldState,
-    onKeyboardAction: KeyboardActionHandler,
     modifier: Modifier = Modifier,
+    keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
+    onKeyboardAction: KeyboardActionHandler? = null,
 ) {
     AuthTextField(
         state = state,
         startIcon = Icons.Outlined.Email,
         hint = "Email",
         modifier = modifier,
-        keyboardOptions = KeyboardOptions(
-            keyboardType = KeyboardType.Email,
-            imeAction = ImeAction.Next,
-        ),
+        keyboardOptions = keyboardOptions,
         onKeyboardAction = onKeyboardAction,
     )
 }
@@ -60,19 +76,18 @@ fun EmailTextField(
 @Composable
 fun PasswordTextField(
     state: TextFieldState,
-    onKeyboardAction: KeyboardActionHandler,
+    hint: String,
     modifier: Modifier = Modifier,
+    keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
+    onKeyboardAction: KeyboardActionHandler? = null,
 ) {
     AuthTextField(
         state = state,
         startIcon = Icons.Outlined.Key,
-        hint = "Password",
+        hint = hint,
         modifier = modifier,
         isPassword = true,
-        keyboardOptions = KeyboardOptions(
-            keyboardType = KeyboardType.Password,
-            imeAction = ImeAction.Done,
-        ),
+        keyboardOptions = keyboardOptions,
         onKeyboardAction = onKeyboardAction,
     )
 }
@@ -162,10 +177,16 @@ private fun AuthTextFieldPreview() {
         Column {
             EmailTextField(
                 state = TextFieldState(),
+                keyboardOptions = KeyboardOptions.Default,
                 onKeyboardAction = { },
             )
             PasswordTextField(
                 state = TextFieldState(),
+                hint = "Password",
+                keyboardOptions = KeyboardOptions(
+                    keyboardType = KeyboardType.Password,
+                    imeAction = ImeAction.Done,
+                ),
                 onKeyboardAction = { },
             )
         }

--- a/frontend/composeApp/src/commonMain/kotlin/com/parksupark/paractice/feature/auth/presentation/di/AuthPresentationModule.kt
+++ b/frontend/composeApp/src/commonMain/kotlin/com/parksupark/paractice/feature/auth/presentation/di/AuthPresentationModule.kt
@@ -1,9 +1,11 @@
 package com.parksupark.paractice.feature.auth.presentation.di
 
 import com.parksupark.paractice.feature.auth.presentation.login.LoginViewModel
+import com.parksupark.paractice.feature.auth.presentation.signup.SignupViewModel
 import org.koin.core.module.dsl.viewModelOf
 import org.koin.dsl.module
 
 val sharedAuthPresentationModule = module {
     viewModelOf(::LoginViewModel)
+    viewModelOf(::SignupViewModel)
 }

--- a/frontend/composeApp/src/commonMain/kotlin/com/parksupark/paractice/feature/auth/presentation/login/LoginScreen.kt
+++ b/frontend/composeApp/src/commonMain/kotlin/com/parksupark/paractice/feature/auth/presentation/login/LoginScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -14,6 +15,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import com.parksupark.paractice.core.designsystem.PTheme
 import com.parksupark.paractice.core.designsystem.components.VerticalSpacer
@@ -50,7 +53,7 @@ private fun LoginContent(
     val passwordState = state.passwordState
 
     Column(
-        modifier = modifier.fillMaxSize(),
+        modifier = modifier,
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
@@ -60,23 +63,28 @@ private fun LoginContent(
         val (first, second) = remember { FocusRequester.createRefs() }
         EmailTextField(
             state = emailState,
-            onKeyboardAction = {
-                second.requestFocus()
-            },
             modifier = Modifier
                 .focusRequester(first)
                 .padding(horizontal = 16.dp),
+            onKeyboardAction = {
+                second.requestFocus()
+            },
         )
         VerticalSpacer(height = 20.dp)
 
         PasswordTextField(
             state = passwordState,
-            onKeyboardAction = {
-                actions.onClickLogin()
-            },
+            hint = "Password",
             modifier = Modifier
                 .focusRequester(second)
                 .padding(horizontal = 16.dp),
+            keyboardOptions = KeyboardOptions(
+                keyboardType = KeyboardType.Password,
+                imeAction = ImeAction.Done,
+            ),
+            onKeyboardAction = {
+                actions.onClickLogin()
+            },
         )
         ForgotPasswordButton(
             onClick = actions.onClickForgotPassword,

--- a/frontend/composeApp/src/commonMain/kotlin/com/parksupark/paractice/feature/auth/presentation/login/LoginScreen.kt
+++ b/frontend/composeApp/src/commonMain/kotlin/com/parksupark/paractice/feature/auth/presentation/login/LoginScreen.kt
@@ -3,6 +3,7 @@ package com.parksupark.paractice.feature.auth.presentation.login
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
@@ -16,11 +17,11 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.unit.dp
 import com.parksupark.paractice.core.designsystem.PTheme
 import com.parksupark.paractice.core.designsystem.components.VerticalSpacer
-import com.parksupark.paractice.feature.auth.presentation.login.components.EmailTextField
-import com.parksupark.paractice.feature.auth.presentation.login.components.ForgotPasswordButton
-import com.parksupark.paractice.feature.auth.presentation.login.components.LoginButton
-import com.parksupark.paractice.feature.auth.presentation.login.components.PasswordTextField
-import com.parksupark.paractice.feature.auth.presentation.login.components.SignUpButton
+import com.parksupark.paractice.feature.auth.presentation.components.EmailTextField
+import com.parksupark.paractice.feature.auth.presentation.components.ForgotPasswordButton
+import com.parksupark.paractice.feature.auth.presentation.components.AuthButton
+import com.parksupark.paractice.feature.auth.presentation.components.PasswordTextField
+import com.parksupark.paractice.feature.auth.presentation.components.SignUpButton
 import org.jetbrains.compose.ui.tooling.preview.Preview
 
 @Composable
@@ -83,7 +84,7 @@ private fun LoginContent(
         )
         VerticalSpacer(height = 24.dp)
 
-        LoginButton(onClick = actions.onClickLogin)
+        AuthButton(text = "Login", onClick = actions.onClickLogin, modifier = Modifier.fillMaxWidth())
         VerticalSpacer(height = 24.dp)
 
         SignUpButton(

--- a/frontend/composeApp/src/commonMain/kotlin/com/parksupark/paractice/feature/auth/presentation/signup/SignupContract.kt
+++ b/frontend/composeApp/src/commonMain/kotlin/com/parksupark/paractice/feature/auth/presentation/signup/SignupContract.kt
@@ -1,0 +1,16 @@
+package com.parksupark.paractice.feature.auth.presentation.signup
+
+import androidx.compose.foundation.text.input.TextFieldState
+
+class SignupState(
+    val usernameState: TextFieldState = TextFieldState(),
+    val emailState: TextFieldState = TextFieldState(),
+    val passwordState: TextFieldState = TextFieldState(),
+    val confirmPasswordState: TextFieldState = TextFieldState(),
+)
+
+data class SignupActions(
+    val onClickBack: () -> Unit = { },
+    val onClickSignup: () -> Unit = { },
+    val onClick: () -> Unit = { },
+)

--- a/frontend/composeApp/src/commonMain/kotlin/com/parksupark/paractice/feature/auth/presentation/signup/SignupCoordinator.kt
+++ b/frontend/composeApp/src/commonMain/kotlin/com/parksupark/paractice/feature/auth/presentation/signup/SignupCoordinator.kt
@@ -1,0 +1,24 @@
+package com.parksupark.paractice.feature.auth.presentation.signup
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import org.koin.compose.viewmodel.koinViewModel
+
+/**
+ * Screen's coordinator which is responsible for handling actions from the UI layer
+ * and one-shot actions based on the new UI state
+ */
+class SignupCoordinator(
+    val viewModel: SignupViewModel,
+) {
+    val screenStateFlow = viewModel.uiStateFlow
+}
+
+@Composable
+fun rememberSignupCoordinator(viewModel: SignupViewModel = koinViewModel()): SignupCoordinator {
+    return remember(viewModel) {
+        SignupCoordinator(
+            viewModel = viewModel,
+        )
+    }
+}

--- a/frontend/composeApp/src/commonMain/kotlin/com/parksupark/paractice/feature/auth/presentation/signup/SignupRoute.kt
+++ b/frontend/composeApp/src/commonMain/kotlin/com/parksupark/paractice/feature/auth/presentation/signup/SignupRoute.kt
@@ -1,0 +1,37 @@
+package com.parksupark.paractice.feature.auth.presentation.signup
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+
+@Composable
+fun SignupRoute(
+    navigateUp: () -> Unit,
+    coordinator: SignupCoordinator = rememberSignupCoordinator(),
+) {
+    // State observing and declarations
+    val uiState by coordinator.screenStateFlow.collectAsStateWithLifecycle()
+
+    // UI Actions
+    val actions = rememberSignupActions(
+        navigateUp = navigateUp,
+        coordinator = coordinator,
+    )
+
+    // UI Rendering
+    SignupScreen(state = uiState, actions = actions)
+}
+
+@Composable
+fun rememberSignupActions(
+    navigateUp: () -> Unit,
+    coordinator: SignupCoordinator,
+): SignupActions {
+    return remember(coordinator) {
+        SignupActions(
+            onClickBack = navigateUp,
+            onClickSignup = { },
+        )
+    }
+}

--- a/frontend/composeApp/src/commonMain/kotlin/com/parksupark/paractice/feature/auth/presentation/signup/SignupScreen.kt
+++ b/frontend/composeApp/src/commonMain/kotlin/com/parksupark/paractice/feature/auth/presentation/signup/SignupScreen.kt
@@ -1,0 +1,163 @@
+package com.parksupark.paractice.feature.auth.presentation.signup
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilledIconButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusDirection
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import com.parksupark.paractice.core.designsystem.components.VerticalSpacer
+import com.parksupark.paractice.feature.auth.presentation.components.AuthButton
+import com.parksupark.paractice.feature.auth.presentation.components.EmailTextField
+import com.parksupark.paractice.feature.auth.presentation.components.PasswordTextField
+import com.parksupark.paractice.feature.auth.presentation.components.UsernameTextField
+import org.jetbrains.compose.ui.tooling.preview.Preview
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SignupScreen(
+    state: SignupState,
+    actions: SignupActions,
+) {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { },
+                navigationIcon = {
+                    FilledIconButton(
+                        onClick = actions.onClickBack,
+                        shape = MaterialTheme.shapes.medium,
+                    ) {
+                        Icon(imageVector = Icons.AutoMirrored.Default.ArrowBack, contentDescription = "back")
+                    }
+                },
+            )
+        },
+    ) { innerPadding ->
+        SignupScreenContent(
+            state = state,
+            actions = actions,
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding),
+        )
+    }
+}
+
+@Composable
+private fun SignupScreenContent(
+    state: SignupState,
+    actions: SignupActions,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Spacer(modifier = Modifier.fillMaxHeight(0.1f))
+
+        Text(text = "Create your account", style = MaterialTheme.typography.titleMedium)
+        VerticalSpacer(height = 20.dp)
+
+        SignupForm(
+            usernameState = state.usernameState,
+            emailState = state.emailState,
+            passwordState = state.passwordState,
+            passwordConfirmState = state.confirmPasswordState,
+            onClickSignup = actions.onClickSignup,
+            modifier = Modifier.padding(horizontal = 16.dp),
+        )
+        VerticalSpacer(24.dp)
+
+        AuthButton(
+            text = "Sign up",
+            onClick = actions.onClickSignup,
+            modifier = Modifier.fillMaxWidth(),
+        )
+    }
+}
+
+@Composable
+private fun SignupForm(
+    usernameState: TextFieldState,
+    emailState: TextFieldState,
+    passwordState: TextFieldState,
+    passwordConfirmState: TextFieldState,
+    onClickSignup: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val focusManager = LocalFocusManager.current
+
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(20.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        UsernameTextField(
+            state = usernameState,
+            modifier = Modifier.fillMaxWidth(),
+            keyboardOptions = KeyboardOptions(
+                imeAction = ImeAction.Next,
+            ),
+            onKeyboardAction = { focusManager.moveFocus(FocusDirection.Next) },
+        )
+        EmailTextField(
+            state = emailState,
+            modifier = Modifier.fillMaxWidth(),
+            keyboardOptions = KeyboardOptions(
+                keyboardType = KeyboardType.Email,
+                imeAction = ImeAction.Next,
+            ),
+            onKeyboardAction = { focusManager.moveFocus(FocusDirection.Next) },
+        )
+        PasswordTextField(
+            state = passwordState,
+            hint = "Password",
+            modifier = Modifier.fillMaxWidth(),
+            keyboardOptions = KeyboardOptions(
+                keyboardType = KeyboardType.Password,
+                imeAction = ImeAction.Next,
+            ),
+            onKeyboardAction = { focusManager.moveFocus(FocusDirection.Next) },
+        )
+        PasswordTextField(
+            state = passwordConfirmState,
+            hint = "Confirm Password",
+            modifier = Modifier.fillMaxWidth(),
+            keyboardOptions = KeyboardOptions(
+                keyboardType = KeyboardType.Password,
+                imeAction = ImeAction.Done,
+            ),
+            onKeyboardAction = { onClickSignup() },
+        )
+    }
+}
+
+@Composable
+@Preview
+private fun SignupScreenPreview() {
+    SignupScreen(
+        state = SignupState(),
+        actions = SignupActions(),
+    )
+}

--- a/frontend/composeApp/src/commonMain/kotlin/com/parksupark/paractice/feature/auth/presentation/signup/SignupViewModel.kt
+++ b/frontend/composeApp/src/commonMain/kotlin/com/parksupark/paractice/feature/auth/presentation/signup/SignupViewModel.kt
@@ -1,0 +1,11 @@
+package com.parksupark.paractice.feature.auth.presentation.signup
+
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+class SignupViewModel : ViewModel() {
+    private val _uiStateFlow: MutableStateFlow<SignupState> = MutableStateFlow(SignupState())
+    val uiStateFlow: StateFlow<SignupState> = _uiStateFlow.asStateFlow()
+}


### PR DESCRIPTION
## 변경 사항

- 패키지에서 공통으로 사용하기 위해 패키지 이동
- 회원가입 ui 구현

<img width="50%" src="https://github.com/user-attachments/assets/6a9bf40a-61e8-4a00-867b-48301f1b4e4e" />

## 이슈 번호

closes #35 

## 체크 리스트

- [x] 병합되는 브랜치를 한번 더 확인 해주세요!
- [x] 이슈 번호 연결을 하셨나요?
- [x] 담당자 설정을 하셨나요?
