### PR TITLE
[back] User, ToDo, Comment 엔티티의 간단한 CRUD 구현

### DIFF
--- a/backend/src/main/java/park_su_park/backend/GlobalExceptionHandler.java
+++ b/backend/src/main/java/park_su_park/backend/GlobalExceptionHandler.java
@@ -6,7 +6,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import park_su_park.backend.exception.DuplicateResourceException;
+import park_su_park.backend.exception.ForbiddenAccessException;
 import park_su_park.backend.exception.ResourceNotFoundException;
+import park_su_park.backend.exception.UnauthorizedAccessException;
 
 @ControllerAdvice
 @Slf4j
@@ -18,8 +20,18 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(ResourceNotFoundException.class)
-    public ResponseEntity<String> handleNotFound(ResourceNotFoundException e) {
+    public ResponseEntity<String> handleNotFound(Exception e) {
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
+    }
+
+    @ExceptionHandler(UnauthorizedAccessException.class)
+    public ResponseEntity<String> handleUnauthorized(Exception e) {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(e.getMessage());
+    }
+
+    @ExceptionHandler(ForbiddenAccessException.class)
+    public ResponseEntity<String> handleForbidden(Exception e) {
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(e.getMessage());
     }
 
     @ExceptionHandler(Exception.class)

--- a/backend/src/main/java/park_su_park/backend/controller/AuthController.java
+++ b/backend/src/main/java/park_su_park/backend/controller/AuthController.java
@@ -5,8 +5,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import park_su_park.backend.domain.User;
-import park_su_park.backend.dto.CreateUserRequest;
-import park_su_park.backend.dto.UserDataResponse;
+import park_su_park.backend.dto.requestBody.CreateUserRequest;
+import park_su_park.backend.dto.responseBody.UserDataResponse;
 import park_su_park.backend.service.UserService;
 
 @RestController

--- a/backend/src/main/java/park_su_park/backend/controller/CommentController.java
+++ b/backend/src/main/java/park_su_park/backend/controller/CommentController.java
@@ -6,67 +6,42 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import park_su_park.backend.domain.Comment;
 import park_su_park.backend.dto.requestBody.CreateCommentRequest;
 import park_su_park.backend.dto.responseBody.CommentDataResponse;
-import park_su_park.backend.exception.ForbiddenAccessException;
 import park_su_park.backend.service.CommentService;
-import park_su_park.backend.service.UserService;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/comment")
 public class CommentController {
 
-    private static final String FORBIDDEN_ACCESS_ACTION = "해당 댓글을 수정 및 삭제할 권한이 없습니다";
     private final CommentService commentService;
-    private final UserService userService;
 
     @PostMapping("/create/{toDoId}")
     public ResponseEntity<CommentDataResponse> createComment(@RequestBody @Valid CreateCommentRequest createCommentRequest, @PathVariable Long toDoId, HttpSession session) {
-        Long userId = userService.getUserIdFromSession(session);
+        CommentDataResponse commentDataResponse = commentService.createComment(createCommentRequest, toDoId, session);
 
-        Long commentId = commentService.join(createCommentRequest, userId, toDoId);
-
-        CommentDataResponse commentDataResponse = CommentDataResponse.create(commentService.findComment(commentId));
         return ResponseEntity.status(HttpStatus.CREATED).body(commentDataResponse);
     }
 
     @GetMapping("/{commentId}")
     public ResponseEntity<CommentDataResponse> getComment(@PathVariable Long commentId) {
-        Comment comment = commentService.findComment(commentId);
+        CommentDataResponse commentDataResponse = commentService.getComment(commentId);
 
-        CommentDataResponse commentDataResponse = CommentDataResponse.create(comment);
         return ResponseEntity.ok(commentDataResponse);
     }
 
     @PatchMapping("/{commentId}")
     public ResponseEntity<CommentDataResponse> updateComment(@RequestBody @Valid CreateCommentRequest updateCommentRequest, @PathVariable Long commentId, HttpSession session) {
-        Long userId = userService.getUserIdFromSession(session);
-        Comment comment = commentService.findComment(commentId);
-        validateUserAuthorization(userId,comment);
+        CommentDataResponse commentDataResponse = commentService.updateComment(updateCommentRequest, commentId, session);
 
-        commentService.updateComment(updateCommentRequest, comment);
-
-        CommentDataResponse commentDataResponse = CommentDataResponse.create(comment);
         return ResponseEntity.ok(commentDataResponse);
     }
 
     @DeleteMapping("/{commentId}")
     public ResponseEntity<Void> deleteComment(@PathVariable Long commentId, HttpSession session) {
-        Long userId = userService.getUserIdFromSession(session);
-        Comment comment = commentService.findComment(commentId);
-        validateUserAuthorization(userId, comment);
-
-        commentService.deleteComment(comment);
+        commentService.deleteComment(commentId, session);
 
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
-    }
-
-    //==비즈니스 로직==//
-    private void validateUserAuthorization(Long userId, Comment comment){
-        if (!comment.getUser().getId().equals(userId)) {
-            throw new ForbiddenAccessException(FORBIDDEN_ACCESS_ACTION);
-        }
     }
 }

--- a/backend/src/main/java/park_su_park/backend/controller/CommentController.java
+++ b/backend/src/main/java/park_su_park/backend/controller/CommentController.java
@@ -1,0 +1,72 @@
+package park_su_park.backend.controller;
+
+import jakarta.servlet.http.HttpSession;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import park_su_park.backend.domain.Comment;
+import park_su_park.backend.dto.requestBody.CreateCommentRequest;
+import park_su_park.backend.dto.responseBody.CommentDataResponse;
+import park_su_park.backend.exception.ForbiddenAccessException;
+import park_su_park.backend.service.CommentService;
+import park_su_park.backend.service.UserService;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/comment")
+public class CommentController {
+
+    private static final String FORBIDDEN_ACCESS_ACTION = "해당 댓글을 수정 및 삭제할 권한이 없습니다";
+    private final CommentService commentService;
+    private final UserService userService;
+
+    @PostMapping("/create/{toDoId}")
+    public ResponseEntity<CommentDataResponse> createComment(@RequestBody @Valid CreateCommentRequest createCommentRequest, @PathVariable Long toDoId, HttpSession session) {
+        Long userId = userService.getUserIdFromSession(session);
+
+        Long commentId = commentService.join(createCommentRequest, userId, toDoId);
+
+        CommentDataResponse commentDataResponse = CommentDataResponse.create(commentService.findComment(commentId));
+        return ResponseEntity.status(HttpStatus.CREATED).body(commentDataResponse);
+    }
+
+    @GetMapping("/{commentId}")
+    public ResponseEntity<CommentDataResponse> getComment(@PathVariable Long commentId) {
+        Comment comment = commentService.findComment(commentId);
+
+        CommentDataResponse commentDataResponse = CommentDataResponse.create(comment);
+        return ResponseEntity.ok(commentDataResponse);
+    }
+
+    @PatchMapping("/{commentId}")
+    public ResponseEntity<CommentDataResponse> updateComment(@RequestBody @Valid CreateCommentRequest updateCommentRequest, @PathVariable Long commentId, HttpSession session) {
+        Long userId = userService.getUserIdFromSession(session);
+        Comment comment = commentService.findComment(commentId);
+        validateUserAuthorization(userId,comment);
+
+        commentService.updateComment(updateCommentRequest, comment);
+
+        CommentDataResponse commentDataResponse = CommentDataResponse.create(comment);
+        return ResponseEntity.ok(commentDataResponse);
+    }
+
+    @DeleteMapping("/{commentId}")
+    public ResponseEntity<Void> deleteComment(@PathVariable Long commentId, HttpSession session) {
+        Long userId = userService.getUserIdFromSession(session);
+        Comment comment = commentService.findComment(commentId);
+        validateUserAuthorization(userId, comment);
+
+        commentService.deleteComment(comment);
+
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
+
+    //==비즈니스 로직==//
+    private void validateUserAuthorization(Long userId, Comment comment){
+        if (!comment.getUser().getId().equals(userId)) {
+            throw new ForbiddenAccessException(FORBIDDEN_ACCESS_ACTION);
+        }
+    }
+}

--- a/backend/src/main/java/park_su_park/backend/controller/ToDoController.java
+++ b/backend/src/main/java/park_su_park/backend/controller/ToDoController.java
@@ -1,0 +1,72 @@
+package park_su_park.backend.controller;
+
+import jakarta.servlet.http.HttpSession;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import park_su_park.backend.domain.ToDo;
+import park_su_park.backend.dto.requestBody.CreateToDoRequest;
+import park_su_park.backend.dto.responseBody.ToDoDataResponse;
+import park_su_park.backend.exception.ForbiddenAccessException;
+import park_su_park.backend.service.ToDoService;
+import park_su_park.backend.service.UserService;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/to-do")
+public class ToDoController {
+
+    private static final String FORBIDDEN_ACCESS_ACTION = "해당 댓글을 수정 및 삭제할 권한이 없습니다";
+    private final ToDoService toDoService;
+    private final UserService userService;
+
+    @PostMapping("/create")
+    public ResponseEntity<ToDoDataResponse> createToDo(@RequestBody @Valid CreateToDoRequest createToDoRequest, HttpSession session) {
+        Long userId = userService.getUserIdFromSession(session);
+
+        Long toDoId = toDoService.join(createToDoRequest, userId);
+
+        ToDoDataResponse toDoDataResponse = ToDoDataResponse.create(toDoService.findToDo(toDoId));
+        return ResponseEntity.status(HttpStatus.CREATED).body(toDoDataResponse);
+    }
+
+    @GetMapping("/{toDoId}")
+    public ResponseEntity<ToDoDataResponse> getToDo(@PathVariable Long toDoId) {
+        ToDo toDo = toDoService.findToDo(toDoId);
+
+        ToDoDataResponse toDoDataResponse = ToDoDataResponse.create(toDo);
+        return ResponseEntity.ok(toDoDataResponse);
+    }
+
+    @PatchMapping("/{toDoId}")
+    public ResponseEntity<ToDoDataResponse> updateToDo(@PathVariable Long toDoId, @RequestBody @Valid CreateToDoRequest updateToDoRequest, HttpSession session) {
+        Long userId = userService.getUserIdFromSession(session);
+        ToDo toDo = toDoService.findToDo(toDoId);
+        validateUserAuthorization(userId, toDo);
+
+        toDoService.updateToDo(updateToDoRequest, toDo);
+
+        ToDoDataResponse toDoDataResponse = ToDoDataResponse.create(toDo);
+        return ResponseEntity.ok(toDoDataResponse);
+    }
+
+    @DeleteMapping("/{toDoId}")
+    public ResponseEntity<Void> deleteToDo(@PathVariable Long toDoId, HttpSession session) {
+        Long userId = userService.getUserIdFromSession(session);
+        ToDo toDo = toDoService.findToDo(toDoId);
+        validateUserAuthorization(userId, toDo);
+
+        toDoService.deleteToDo(toDo);
+
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
+
+    //==비즈니스 로직==//
+    private void validateUserAuthorization(Long userId, ToDo toDo){
+        if (!toDo.getUser().getId().equals(userId)) {
+            throw new ForbiddenAccessException(FORBIDDEN_ACCESS_ACTION);
+        }
+    }
+}

--- a/backend/src/main/java/park_su_park/backend/controller/ToDoController.java
+++ b/backend/src/main/java/park_su_park/backend/controller/ToDoController.java
@@ -6,10 +6,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import park_su_park.backend.domain.ToDo;
 import park_su_park.backend.dto.requestBody.CreateToDoRequest;
 import park_su_park.backend.dto.responseBody.ToDoDataResponse;
-import park_su_park.backend.exception.ForbiddenAccessException;
 import park_su_park.backend.service.ToDoService;
 import park_su_park.backend.service.UserService;
 
@@ -18,55 +16,34 @@ import park_su_park.backend.service.UserService;
 @RequestMapping("/to-do")
 public class ToDoController {
 
-    private static final String FORBIDDEN_ACCESS_ACTION = "해당 댓글을 수정 및 삭제할 권한이 없습니다";
     private final ToDoService toDoService;
     private final UserService userService;
 
     @PostMapping("/create")
     public ResponseEntity<ToDoDataResponse> createToDo(@RequestBody @Valid CreateToDoRequest createToDoRequest, HttpSession session) {
-        Long userId = userService.getUserIdFromSession(session);
+        ToDoDataResponse toDoDataResponse = toDoService.createToDo(createToDoRequest, session);
 
-        Long toDoId = toDoService.join(createToDoRequest, userId);
-
-        ToDoDataResponse toDoDataResponse = ToDoDataResponse.create(toDoService.findToDo(toDoId));
         return ResponseEntity.status(HttpStatus.CREATED).body(toDoDataResponse);
     }
 
     @GetMapping("/{toDoId}")
     public ResponseEntity<ToDoDataResponse> getToDo(@PathVariable Long toDoId) {
-        ToDo toDo = toDoService.findToDo(toDoId);
+        ToDoDataResponse toDoDataResponse = toDoService.getToDo(toDoId);
 
-        ToDoDataResponse toDoDataResponse = ToDoDataResponse.create(toDo);
         return ResponseEntity.ok(toDoDataResponse);
     }
 
     @PatchMapping("/{toDoId}")
     public ResponseEntity<ToDoDataResponse> updateToDo(@PathVariable Long toDoId, @RequestBody @Valid CreateToDoRequest updateToDoRequest, HttpSession session) {
-        Long userId = userService.getUserIdFromSession(session);
-        ToDo toDo = toDoService.findToDo(toDoId);
-        validateUserAuthorization(userId, toDo);
+        ToDoDataResponse toDoDataResponse = toDoService.updateToDo(updateToDoRequest, toDoId, session);
 
-        toDoService.updateToDo(updateToDoRequest, toDo);
-
-        ToDoDataResponse toDoDataResponse = ToDoDataResponse.create(toDo);
         return ResponseEntity.ok(toDoDataResponse);
     }
 
     @DeleteMapping("/{toDoId}")
     public ResponseEntity<Void> deleteToDo(@PathVariable Long toDoId, HttpSession session) {
-        Long userId = userService.getUserIdFromSession(session);
-        ToDo toDo = toDoService.findToDo(toDoId);
-        validateUserAuthorization(userId, toDo);
-
-        toDoService.deleteToDo(toDo);
+        toDoService.deleteToDo(toDoId, session);
 
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
-    }
-
-    //==비즈니스 로직==//
-    private void validateUserAuthorization(Long userId, ToDo toDo){
-        if (!toDo.getUser().getId().equals(userId)) {
-            throw new ForbiddenAccessException(FORBIDDEN_ACCESS_ACTION);
-        }
     }
 }

--- a/backend/src/main/java/park_su_park/backend/controller/ToDoController.java
+++ b/backend/src/main/java/park_su_park/backend/controller/ToDoController.java
@@ -9,7 +9,6 @@ import org.springframework.web.bind.annotation.*;
 import park_su_park.backend.dto.requestBody.CreateToDoRequest;
 import park_su_park.backend.dto.responseBody.ToDoDataResponse;
 import park_su_park.backend.service.ToDoService;
-import park_su_park.backend.service.UserService;
 
 @RestController
 @RequiredArgsConstructor
@@ -17,7 +16,6 @@ import park_su_park.backend.service.UserService;
 public class ToDoController {
 
     private final ToDoService toDoService;
-    private final UserService userService;
 
     @PostMapping("/create")
     public ResponseEntity<ToDoDataResponse> createToDo(@RequestBody @Valid CreateToDoRequest createToDoRequest, HttpSession session) {

--- a/backend/src/main/java/park_su_park/backend/controller/UserController.java
+++ b/backend/src/main/java/park_su_park/backend/controller/UserController.java
@@ -7,7 +7,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import park_su_park.backend.domain.User;
-import park_su_park.backend.dto.UserDataResponse;
+import park_su_park.backend.dto.responseBody.UserDataResponse;
 import park_su_park.backend.service.UserService;
 
 @RestController

--- a/backend/src/main/java/park_su_park/backend/domain/Comment.java
+++ b/backend/src/main/java/park_su_park/backend/domain/Comment.java
@@ -2,11 +2,20 @@ package park_su_park.backend.domain;
 
 import jakarta.persistence.*;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import park_su_park.backend.dto.requestBody.CreateCommentRequest;
+
+import java.time.LocalDateTime;
 
 @Entity
 @Getter
 @Setter
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor
 public class Comment {
 
     @Id
@@ -21,4 +30,39 @@ public class Comment {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "to_do_id")
     private ToDo toDo;
+
+    private String content;
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdTime;
+
+    @LastModifiedDate
+    private LocalDateTime updateTime;
+
+    //==생성자==//
+    private Comment(String content) {
+        this.content = content;
+    }
+
+    //==생성 메서드==//
+    public static Comment create(CreateCommentRequest createCommentRequest) {
+        return new Comment(createCommentRequest.getContent());
+    }
+
+    //==연관 관계 매핑 메서드==//
+    public void setUser(User user){
+        this.user = user;
+        user.getComments().add(this);
+    }
+
+    public void setToDo(ToDo toDo) {
+        this.toDo = toDo;
+        toDo.getComments().add(this);
+    }
+
+    //==비즈니스 로직==//
+    public void update(CreateCommentRequest updateCommentRequest) {
+        this.content = updateCommentRequest.getContent();
+    }
 }

--- a/backend/src/main/java/park_su_park/backend/domain/ToDo.java
+++ b/backend/src/main/java/park_su_park/backend/domain/ToDo.java
@@ -2,7 +2,12 @@ package park_su_park.backend.domain;
 
 import jakarta.persistence.*;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import park_su_park.backend.dto.requestBody.CreateToDoRequest;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -10,6 +15,8 @@ import java.util.List;
 
 @Entity
 @Getter @Setter
+@EntityListeners({AuditingEntityListener.class})
+@NoArgsConstructor
 public class ToDo {
     @Id @GeneratedValue
     @Column(name = "to_do_id")
@@ -26,7 +33,33 @@ public class ToDo {
 
     private String content;
 
+    @CreatedDate
+    @Column(updatable = false)
     private LocalDateTime createdTime;
 
+    @LastModifiedDate
     private LocalDateTime updateTime;
+
+    //==생성자==//
+    private ToDo(String title, String content) {
+        this.title = title;
+        this.content = content;
+    }
+
+    //==생성 메서드==//
+    public static ToDo create(CreateToDoRequest createToDoRequest) {
+        return new ToDo(createToDoRequest.getTitle(), createToDoRequest.getContent());
+    }
+
+    //==연관 관계 매핑 메서드==//
+    public void setUser(User user) {
+        this.user = user;
+        user.getToDos().add(this);
+    }
+
+    //==비즈니스 로직==//
+    public void update(CreateToDoRequest updateToDoRequest) {
+        this.title = updateToDoRequest.getTitle();
+        this.content = updateToDoRequest.getContent();
+    }
 }

--- a/backend/src/main/java/park_su_park/backend/domain/User.java
+++ b/backend/src/main/java/park_su_park/backend/domain/User.java
@@ -7,7 +7,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
-import park_su_park.backend.dto.CreateUserRequest;
+import park_su_park.backend.dto.requestBody.CreateUserRequest;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -23,7 +23,7 @@ public class User {
     private Long id;
 
     @OneToMany(mappedBy = "user")
-    private List<ToDo> toDoes = new ArrayList<>();
+    private List<ToDo> toDos = new ArrayList<>();
 
     @OneToMany(mappedBy = "user")
     private List<Comment> comments = new ArrayList<>();
@@ -46,7 +46,7 @@ public class User {
     }
 
     //==생성 메서드==//
-    public static User createUser(CreateUserRequest createUserRequest) {
+    public static User create(CreateUserRequest createUserRequest) {
         return new User(createUserRequest.getUsername(), createUserRequest.getRawPassword(), createUserRequest.getEmail());
     }
 }

--- a/backend/src/main/java/park_su_park/backend/dto/requestBody/CreateCommentRequest.java
+++ b/backend/src/main/java/park_su_park/backend/dto/requestBody/CreateCommentRequest.java
@@ -1,0 +1,13 @@
+package park_su_park.backend.dto.requestBody;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class CreateCommentRequest {
+
+    @NotBlank
+    private final String content;
+}

--- a/backend/src/main/java/park_su_park/backend/dto/requestBody/CreateToDoRequest.java
+++ b/backend/src/main/java/park_su_park/backend/dto/requestBody/CreateToDoRequest.java
@@ -1,0 +1,16 @@
+package park_su_park.backend.dto.requestBody;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class CreateToDoRequest {
+
+    @NotBlank
+    private final String title;
+
+    @NotBlank
+    private final String content;
+}

--- a/backend/src/main/java/park_su_park/backend/dto/requestBody/CreateUserRequest.java
+++ b/backend/src/main/java/park_su_park/backend/dto/requestBody/CreateUserRequest.java
@@ -1,4 +1,4 @@
-package park_su_park.backend.dto;
+package park_su_park.backend.dto.requestBody;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;

--- a/backend/src/main/java/park_su_park/backend/dto/responseBody/CommentDataResponse.java
+++ b/backend/src/main/java/park_su_park/backend/dto/responseBody/CommentDataResponse.java
@@ -1,0 +1,25 @@
+package park_su_park.backend.dto.responseBody;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import park_su_park.backend.domain.Comment;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class CommentDataResponse {
+
+    private final Long commentId;
+    private final Long userId;
+    private final Long toDoId;
+    private final String content;
+    private final LocalDateTime createdTime;
+    private final LocalDateTime updateTime;
+
+    //==생성 메서드==//
+    public static CommentDataResponse create(Comment comment) {
+        return new CommentDataResponse(comment.getId(), comment.getUser().getId(), comment.getToDo().getId(), comment.getContent(), comment.getCreatedTime(), comment.getUpdateTime());
+    }
+}

--- a/backend/src/main/java/park_su_park/backend/dto/responseBody/ToDoDataResponse.java
+++ b/backend/src/main/java/park_su_park/backend/dto/responseBody/ToDoDataResponse.java
@@ -1,0 +1,25 @@
+package park_su_park.backend.dto.responseBody;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import park_su_park.backend.domain.ToDo;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ToDoDataResponse {
+
+    private final Long toDoId;
+    private final Long userId;
+    private final String title;
+    private final String content;
+    private final LocalDateTime createdTime;
+    private final LocalDateTime updateTime;
+
+    //==생성 메서드==//
+    public static ToDoDataResponse create(ToDo toDo){
+        return new ToDoDataResponse(toDo.getId(), toDo.getUser().getId(), toDo.getTitle(), toDo.getContent(), toDo.getCreatedTime(), toDo.getUpdateTime());
+    }
+}

--- a/backend/src/main/java/park_su_park/backend/dto/responseBody/UserDataResponse.java
+++ b/backend/src/main/java/park_su_park/backend/dto/responseBody/UserDataResponse.java
@@ -1,4 +1,4 @@
-package park_su_park.backend.dto;
+package park_su_park.backend.dto.responseBody;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;

--- a/backend/src/main/java/park_su_park/backend/exception/ForbiddenAccessException.java
+++ b/backend/src/main/java/park_su_park/backend/exception/ForbiddenAccessException.java
@@ -1,0 +1,7 @@
+package park_su_park.backend.exception;
+
+public class ForbiddenAccessException extends RuntimeException{
+    public ForbiddenAccessException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/park_su_park/backend/exception/UnauthorizedAccessException.java
+++ b/backend/src/main/java/park_su_park/backend/exception/UnauthorizedAccessException.java
@@ -1,0 +1,7 @@
+package park_su_park.backend.exception;
+
+public class UnauthorizedAccessException extends RuntimeException{
+    public UnauthorizedAccessException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/park_su_park/backend/repository/CommentRepository.java
+++ b/backend/src/main/java/park_su_park/backend/repository/CommentRepository.java
@@ -1,31 +1,9 @@
 package park_su_park.backend.repository;
 
-import jakarta.persistence.EntityManager;
-import lombok.RequiredArgsConstructor;
+import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import park_su_park.backend.domain.Comment;
 
-import java.util.List;
-
 @Repository
-@RequiredArgsConstructor
-public class CommentRepository {
-
-    private final EntityManager em;
-
-    public void save(Comment comment) {
-        em.persist(comment);
-    }
-
-    public Comment findOne(Long commentId) {
-        return em.find(Comment.class, commentId);
-    }
-
-    public List<Comment> findAll() {
-        return em.createQuery("select c from Comment c",Comment.class).getResultList();
-    }
-
-    public void remove(Comment comment) {
-        em.remove(comment);
-    }
+public interface CommentRepository extends JpaRepository<Comment, Long> {
 }

--- a/backend/src/main/java/park_su_park/backend/repository/ToDoRepository.java
+++ b/backend/src/main/java/park_su_park/backend/repository/ToDoRepository.java
@@ -1,31 +1,10 @@
 package park_su_park.backend.repository;
 
-import jakarta.persistence.EntityManager;
-import lombok.RequiredArgsConstructor;
+import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import park_su_park.backend.domain.ToDo;
 
-import java.util.List;
-
 @Repository
-@RequiredArgsConstructor
-public class ToDoRepository {
-    private final EntityManager em;
-
-    public void save(ToDo toDo) {
-        em.persist(toDo);
-    }
-
-    public ToDo findOne(Long toDoId) {
-        return em.find(ToDo.class, toDoId);
-    }
-
-    public List<ToDo> findAll() {
-        return em.createQuery("select t from ToDo t",ToDo.class).getResultList();
-    }
-
-    public void remove(ToDo toDo) {
-        em.remove(toDo);
-    }
+public interface ToDoRepository extends JpaRepository<ToDo, Long> {
 
 }

--- a/backend/src/main/java/park_su_park/backend/service/CommentService.java
+++ b/backend/src/main/java/park_su_park/backend/service/CommentService.java
@@ -1,0 +1,51 @@
+package park_su_park.backend.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import park_su_park.backend.domain.Comment;
+import park_su_park.backend.domain.ToDo;
+import park_su_park.backend.domain.User;
+import park_su_park.backend.dto.requestBody.CreateCommentRequest;
+import park_su_park.backend.exception.ResourceNotFoundException;
+import park_su_park.backend.repository.CommentRepository;
+
+import java.text.MessageFormat;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class CommentService {
+
+    private final CommentRepository commentRepository;
+    private final UserService userService;
+    private final ToDoService toDoService;
+
+    public Long join(CreateCommentRequest createCommentRequest, Long userId, Long toDoId) {
+        Comment comment = Comment.create(createCommentRequest);
+        User user = userService.findUserById(userId);
+        ToDo toDo = toDoService.findToDo(toDoId);
+        comment.setUser(user);
+        comment.setToDo(toDo);
+
+        Comment savedComment = commentRepository.save(comment);
+
+        return savedComment.getId();
+    }
+
+    @Transactional(readOnly = true)
+    public Comment findComment(Long commentId){
+        return commentRepository.findById(commentId)
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        MessageFormat.format("해당 id 를 가진 댓글을 찾을 수 없습니다: {0}", commentId)
+                ));
+    }
+
+    public void updateComment(CreateCommentRequest updateCommentRequest, Comment oldComment) {
+        oldComment.update(updateCommentRequest);
+    }
+
+    public void deleteComment(Comment comment) {
+        commentRepository.delete(comment);
+    }
+}

--- a/backend/src/main/java/park_su_park/backend/service/ToDoService.java
+++ b/backend/src/main/java/park_su_park/backend/service/ToDoService.java
@@ -1,0 +1,47 @@
+package park_su_park.backend.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import park_su_park.backend.domain.ToDo;
+import park_su_park.backend.domain.User;
+import park_su_park.backend.dto.requestBody.CreateToDoRequest;
+import park_su_park.backend.exception.ResourceNotFoundException;
+import park_su_park.backend.repository.ToDoRepository;
+
+import java.text.MessageFormat;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ToDoService {
+
+    private final ToDoRepository toDoRepository;
+    private final UserService userService;
+
+    public Long join(CreateToDoRequest createToDoRequest, Long userId) {
+        ToDo toDo = ToDo.create(createToDoRequest);
+
+        User user = userService.findUserById(userId);
+        toDo.setUser(user);
+        ToDo savedToDo = toDoRepository.save(toDo);
+
+        return savedToDo.getId();
+    }
+
+    @Transactional(readOnly = true)
+    public ToDo findToDo(Long toDoId) {
+        return toDoRepository.findById(toDoId)
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        MessageFormat.format("해당 id 를 가진 일정을 찾을 수 없습니다: {0}", toDoId)
+                ));
+    }
+
+    public void updateToDo(CreateToDoRequest updateToDoRequest, ToDo oldToDo){
+        oldToDo.update(updateToDoRequest);
+    }
+
+    public void deleteToDo(ToDo toDo) {
+        toDoRepository.delete(toDo);
+    }
+}

--- a/backend/src/main/java/park_su_park/backend/service/ToDoService.java
+++ b/backend/src/main/java/park_su_park/backend/service/ToDoService.java
@@ -1,13 +1,17 @@
 package park_su_park.backend.service;
 
+import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import park_su_park.backend.domain.ToDo;
 import park_su_park.backend.domain.User;
 import park_su_park.backend.dto.requestBody.CreateToDoRequest;
+import park_su_park.backend.dto.responseBody.ToDoDataResponse;
+import park_su_park.backend.exception.ForbiddenAccessException;
 import park_su_park.backend.exception.ResourceNotFoundException;
 import park_su_park.backend.repository.ToDoRepository;
+import park_su_park.backend.util.SessionUtil;
 
 import java.text.MessageFormat;
 
@@ -16,17 +20,23 @@ import java.text.MessageFormat;
 @RequiredArgsConstructor
 public class ToDoService {
 
+    private static final String FORBIDDEN_ACCESS_ACTION = "해당 일정을 수정 및 삭제할 권한이 없습니다";
     private final ToDoRepository toDoRepository;
     private final UserService userService;
 
-    public Long join(CreateToDoRequest createToDoRequest, Long userId) {
-        ToDo toDo = ToDo.create(createToDoRequest);
-
+    public ToDoDataResponse createToDo(CreateToDoRequest createToDoRequest, HttpSession session) {
+        Long userId = SessionUtil.getUserIdFromSession(session);
         User user = userService.findUserById(userId);
-        toDo.setUser(user);
-        ToDo savedToDo = toDoRepository.save(toDo);
 
-        return savedToDo.getId();
+        ToDo toDo = saveToDo(createToDoRequest, user);
+        return ToDoDataResponse.create(toDo);
+    }
+
+    private ToDo saveToDo(CreateToDoRequest createToDoRequest, User user) {
+        ToDo toDo = ToDo.create(createToDoRequest);
+        toDo.setUser(user);
+
+        return toDoRepository.save(toDo);
     }
 
     @Transactional(readOnly = true)
@@ -37,11 +47,33 @@ public class ToDoService {
                 ));
     }
 
-    public void updateToDo(CreateToDoRequest updateToDoRequest, ToDo oldToDo){
-        oldToDo.update(updateToDoRequest);
+    public ToDoDataResponse getToDo(Long toDoId) {
+        ToDo toDo = findToDo(toDoId);
+
+        return ToDoDataResponse.create(toDo);
     }
 
-    public void deleteToDo(ToDo toDo) {
+    public ToDoDataResponse updateToDo(CreateToDoRequest updateToDoRequest, Long toDoId, HttpSession session) {
+        ToDo toDo = getAuthorizedToDo(toDoId, session);
+        toDo.update(updateToDoRequest);
+
+        return ToDoDataResponse.create(toDo);
+    }
+
+    public void deleteToDo(Long toDoId, HttpSession session) {
+        ToDo toDo = getAuthorizedToDo(toDoId, session);
+
         toDoRepository.delete(toDo);
+    }
+
+    private ToDo getAuthorizedToDo(Long toDoId, HttpSession session) {
+        Long userId = SessionUtil.getUserIdFromSession(session);
+        ToDo toDo = findToDo(toDoId);
+
+        if (!toDo.getUser().getId().equals(userId)) {
+            throw new ForbiddenAccessException(FORBIDDEN_ACCESS_ACTION);
+        }
+
+        return toDo;
     }
 }

--- a/backend/src/main/java/park_su_park/backend/service/UserService.java
+++ b/backend/src/main/java/park_su_park/backend/service/UserService.java
@@ -1,6 +1,5 @@
 package park_su_park.backend.service;
 
-import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -8,7 +7,6 @@ import park_su_park.backend.domain.User;
 import park_su_park.backend.dto.requestBody.CreateUserRequest;
 import park_su_park.backend.exception.DuplicateResourceException;
 import park_su_park.backend.exception.ResourceNotFoundException;
-import park_su_park.backend.exception.UnauthorizedAccessException;
 import park_su_park.backend.repository.UserRepository;
 
 import java.text.MessageFormat;
@@ -18,7 +16,6 @@ import java.text.MessageFormat;
 @RequiredArgsConstructor
 public class UserService {
 
-    private final static String UNAUTHORIZED_ACCESS_ACTION = "로그인 정보가 유효하지 않거나 만료 되었습니다.";
     private final UserRepository userRepository;
 
     public Long join(CreateUserRequest createUserRequest) {
@@ -65,13 +62,5 @@ public class UserService {
                             MessageFormat.format("다른 사용자가 사용중인 email 입니다: {0}", createUserRequest.getEmail())
                     );
                 });
-    }
-
-    public Long getUserIdFromSession(HttpSession session) {
-        Long userId = (Long) session.getAttribute("userId");
-        if (userId == null) {
-            throw new UnauthorizedAccessException(UNAUTHORIZED_ACCESS_ACTION);
-        }
-        return userId;
     }
 }

--- a/backend/src/main/java/park_su_park/backend/util/SessionUtil.java
+++ b/backend/src/main/java/park_su_park/backend/util/SessionUtil.java
@@ -1,0 +1,18 @@
+package park_su_park.backend.util;
+
+import jakarta.servlet.http.HttpSession;
+import park_su_park.backend.exception.UnauthorizedAccessException;
+
+public class SessionUtil {
+
+    private static final String USER_ID_SESSION_KEY = "userId";
+    private final static String UNAUTHORIZED_ACCESS_ACTION = "로그인 정보가 유효하지 않거나 만료 되었습니다.";
+
+    public static Long getUserIdFromSession(HttpSession session) {
+        Long userId = (Long) session.getAttribute(USER_ID_SESSION_KEY);
+        if (userId == null) {
+            throw new UnauthorizedAccessException(UNAUTHORIZED_ACCESS_ACTION);
+        }
+        return userId;
+    }
+}


### PR DESCRIPTION
## 변경 사항
- 세 엔티티의 간단한 CRUD를 3 layer architecture 를 따라 구현했습니다.
- findAll 과 같은 기능은 페이징 조회 기능추가할때 같이 구현할 예정입니다.
- 현재 AOP에 대한 지식수준이 부족한 상태라 학습 후에 적용할 예정입니다. 

## 이슈 번호
closes #31 
## 체크 리스트

- [x] 병합되는 브랜치를 한번 더 확인 해주세요!
- [x] 이슈 번호 연결을 하셨나요?
- [x] 담당자 설정을 하셨나요?
