### PR TITLE
[back] request body validation 및 비밀번호 암호화

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'at.favre.lib:bcrypt:0.10.2'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.h2database:h2'

--- a/backend/src/main/java/park_su_park/backend/GlobalExceptionHandler.java
+++ b/backend/src/main/java/park_su_park/backend/GlobalExceptionHandler.java
@@ -3,39 +3,56 @@ package park_su_park.backend;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import park_su_park.backend.dto.responseBody.ApiResponseBody;
+import park_su_park.backend.dto.responseBody.ValidationFailureData;
 import park_su_park.backend.exception.*;
+
+import java.util.HashMap;
+import java.util.Map;
 
 @ControllerAdvice
 @Slf4j
 public class GlobalExceptionHandler {
 
-    @ExceptionHandler({DuplicateResourceException.class, IllegalArgumentException.class, MethodArgumentNotValidException.class, IllegalStateException.class})
+    @ExceptionHandler({DuplicateResourceException.class, IllegalArgumentException.class, IllegalStateException.class})
     public ResponseEntity<ApiResponseBody> handleBadRequest(Exception e) {
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ApiResponseBody.failure(e.getMessage()));
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ApiResponseBody.create(e.getMessage()));
     }
 
     @ExceptionHandler(ResourceNotFoundException.class)
     public ResponseEntity<ApiResponseBody> handleNotFound(Exception e) {
-        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ApiResponseBody.failure(e.getMessage()));
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ApiResponseBody.create(e.getMessage()));
     }
 
     @ExceptionHandler({UnauthorizedAccessException.class, AuthenticationFailedException.class})
     public ResponseEntity<ApiResponseBody> handleUnauthorized(Exception e) {
-        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponseBody.failure(e.getMessage()));
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponseBody.create(e.getMessage()));
     }
 
     @ExceptionHandler(ForbiddenAccessException.class)
     public ResponseEntity<ApiResponseBody> handleForbidden(Exception e) {
-        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(ApiResponseBody.failure(e.getMessage()));
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(ApiResponseBody.create(e.getMessage()));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponseBody> handleRequestBodyNotValid(MethodArgumentNotValidException e) {
+        Map<String, String> fieldErrors = new HashMap<>();
+
+        for (FieldError fieldError : e.getBindingResult().getFieldErrors()) {
+            fieldErrors.put(fieldError.getField(), fieldError.getDefaultMessage());
+        }
+
+        ValidationFailureData validationFailureData = ValidationFailureData.create(fieldErrors);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ApiResponseBody.create("검증 실패", validationFailureData));
     }
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ApiResponseBody> handleUnknownError(Exception e) {
         log.error("Unexpected error occurred : {}", e.getMessage());
-        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(ApiResponseBody.failure("서버 내부 오류 발생"));
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(ApiResponseBody.create("서버 내부 오류 발생"));
     }
 }

--- a/backend/src/main/java/park_su_park/backend/controller/AuthController.java
+++ b/backend/src/main/java/park_su_park/backend/controller/AuthController.java
@@ -25,7 +25,7 @@ public class AuthController {
     public ResponseEntity<ApiResponseBody> signUp(@RequestBody @Valid CreateUserRequest createUserRequest) {
         UserData userData = authService.signUp(createUserRequest);
 
-        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponseBody.success(AuthResponseMessage.SIGN_IN_SUCCESS, userData));
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponseBody.create(AuthResponseMessage.SIGN_IN_SUCCESS, userData));
     }
 
     @PostMapping("/login")
@@ -33,7 +33,7 @@ public class AuthController {
         HttpSession session = request.getSession();
         authService.login(loginRequest, session);
 
-        return ResponseEntity.ok(ApiResponseBody.success(AuthResponseMessage.LOGIN_SUCCESS, null));
+        return ResponseEntity.ok(ApiResponseBody.create(AuthResponseMessage.LOGIN_SUCCESS, null));
     }
 
     @PostMapping("/logout")
@@ -41,6 +41,6 @@ public class AuthController {
         HttpSession session = request.getSession(false);
         authService.logout(session);
 
-        return ResponseEntity.ok(ApiResponseBody.success(AuthResponseMessage.LOGOUT_SUCCESS, null));
+        return ResponseEntity.ok(ApiResponseBody.create(AuthResponseMessage.LOGOUT_SUCCESS, null));
     }
 }

--- a/backend/src/main/java/park_su_park/backend/controller/CommentController.java
+++ b/backend/src/main/java/park_su_park/backend/controller/CommentController.java
@@ -23,27 +23,27 @@ public class CommentController {
     public ResponseEntity<ApiResponseBody> createComment(@RequestBody @Valid CreateCommentRequest createCommentRequest, @PathVariable Long toDoId, HttpSession session) {
         CommentData commentData = commentService.createComment(createCommentRequest, toDoId, session);
 
-        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponseBody.success(CommentResponseMessage.COMMENT_CREATION_SUCCESS, commentData));
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponseBody.create(CommentResponseMessage.COMMENT_CREATION_SUCCESS, commentData));
     }
 
     @GetMapping("/{commentId}")
     public ResponseEntity<ApiResponseBody> getComment(@PathVariable Long commentId) {
         CommentData commentData = commentService.getComment(commentId);
 
-        return ResponseEntity.ok(ApiResponseBody.success(CommentResponseMessage.COMMENT_FETCH_SUCCESS, commentData));
+        return ResponseEntity.ok(ApiResponseBody.create(CommentResponseMessage.COMMENT_FETCH_SUCCESS, commentData));
     }
 
     @PatchMapping("/{commentId}")
     public ResponseEntity<ApiResponseBody> updateComment(@RequestBody @Valid CreateCommentRequest updateCommentRequest, @PathVariable Long commentId, HttpSession session) {
         CommentData commentData = commentService.updateComment(updateCommentRequest, commentId, session);
 
-        return ResponseEntity.ok(ApiResponseBody.success(CommentResponseMessage.COMMENT_UPDATE_SUCCESS, commentData));
+        return ResponseEntity.ok(ApiResponseBody.create(CommentResponseMessage.COMMENT_UPDATE_SUCCESS, commentData));
     }
 
     @DeleteMapping("/{commentId}")
     public ResponseEntity<ApiResponseBody> deleteComment(@PathVariable Long commentId, HttpSession session) {
         commentService.deleteComment(commentId, session);
 
-        return ResponseEntity.ok(ApiResponseBody.success(CommentResponseMessage.COMMENT_DELETION_SUCCESS, null));
+        return ResponseEntity.ok(ApiResponseBody.create(CommentResponseMessage.COMMENT_DELETION_SUCCESS, null));
     }
 }

--- a/backend/src/main/java/park_su_park/backend/controller/ToDoController.java
+++ b/backend/src/main/java/park_su_park/backend/controller/ToDoController.java
@@ -23,27 +23,27 @@ public class ToDoController {
     public ResponseEntity<ApiResponseBody> createToDo(@RequestBody @Valid CreateToDoRequest createToDoRequest, HttpSession session) {
         ToDoData toDoData = toDoService.createToDo(createToDoRequest, session);
 
-        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponseBody.success(ToDoResponseMessage.TODO_CREATION_SUCCESS, toDoData));
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponseBody.create(ToDoResponseMessage.TODO_CREATION_SUCCESS, toDoData));
     }
 
     @GetMapping("/{toDoId}")
     public ResponseEntity<ApiResponseBody> getToDo(@PathVariable Long toDoId) {
         ToDoData toDoData = toDoService.getToDoData(toDoId);
 
-        return ResponseEntity.ok(ApiResponseBody.success(ToDoResponseMessage.TODO_FETCH_SUCCESS, toDoData));
+        return ResponseEntity.ok(ApiResponseBody.create(ToDoResponseMessage.TODO_FETCH_SUCCESS, toDoData));
     }
 
     @PatchMapping("/{toDoId}")
     public ResponseEntity<ApiResponseBody> updateToDo(@PathVariable Long toDoId, @RequestBody @Valid CreateToDoRequest updateToDoRequest, HttpSession session) {
         ToDoData toDoData = toDoService.updateToDo(updateToDoRequest, toDoId, session);
 
-        return ResponseEntity.ok(ApiResponseBody.success(ToDoResponseMessage.TODO_UPDATE_SUCCESS, toDoData));
+        return ResponseEntity.ok(ApiResponseBody.create(ToDoResponseMessage.TODO_UPDATE_SUCCESS, toDoData));
     }
 
     @DeleteMapping("/{toDoId}")
     public ResponseEntity<ApiResponseBody> deleteToDo(@PathVariable Long toDoId, HttpSession session) {
         toDoService.deleteToDo(toDoId, session);
 
-        return ResponseEntity.ok(ApiResponseBody.success(ToDoResponseMessage.TODO_DELETION_SUCCESS, null));
+        return ResponseEntity.ok(ApiResponseBody.create(ToDoResponseMessage.TODO_DELETION_SUCCESS, null));
     }
 }

--- a/backend/src/main/java/park_su_park/backend/dto/requestBody/CreateCommentRequest.java
+++ b/backend/src/main/java/park_su_park/backend/dto/requestBody/CreateCommentRequest.java
@@ -1,13 +1,13 @@
 package park_su_park.backend.dto.requestBody;
 
-import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import park_su_park.backend.util.validation.Content;
 
 @Getter
 @RequiredArgsConstructor
 public class CreateCommentRequest {
 
-    @NotBlank
+    @Content
     private final String content;
 }

--- a/backend/src/main/java/park_su_park/backend/dto/requestBody/CreateToDoRequest.java
+++ b/backend/src/main/java/park_su_park/backend/dto/requestBody/CreateToDoRequest.java
@@ -1,16 +1,17 @@
 package park_su_park.backend.dto.requestBody;
 
-import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import park_su_park.backend.util.validation.Content;
+import park_su_park.backend.util.validation.Title;
 
 @Getter
 @RequiredArgsConstructor
 public class CreateToDoRequest {
 
-    @NotBlank
+    @Title
     private final String title;
 
-    @NotBlank
+    @Content
     private final String content;
 }

--- a/backend/src/main/java/park_su_park/backend/dto/requestBody/CreateUserRequest.java
+++ b/backend/src/main/java/park_su_park/backend/dto/requestBody/CreateUserRequest.java
@@ -1,21 +1,21 @@
 package park_su_park.backend.dto.requestBody;
 
-import jakarta.validation.constraints.Email;
-import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import park_su_park.backend.util.validation.EmailCustom;
+import park_su_park.backend.util.validation.Password;
+import park_su_park.backend.util.validation.Username;
 
 @Getter
 @RequiredArgsConstructor
 public class CreateUserRequest {
 
-    @NotBlank
+    @Username
     private final String username;
 
-    @NotBlank
+    @Password
     private final String rawPassword;
 
-    @Email
-    @NotBlank
+    @EmailCustom
     private final String email;
 }

--- a/backend/src/main/java/park_su_park/backend/dto/requestBody/LoginRequest.java
+++ b/backend/src/main/java/park_su_park/backend/dto/requestBody/LoginRequest.java
@@ -1,7 +1,5 @@
 package park_su_park.backend.dto.requestBody;
 
-import jakarta.validation.constraints.Email;
-import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -9,10 +7,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class LoginRequest {
 
-    @NotBlank
-    @Email
     private final String email;
 
-    @NotBlank
     private final String rawPassword;
 }

--- a/backend/src/main/java/park_su_park/backend/dto/responseBody/ApiResponseBody.java
+++ b/backend/src/main/java/park_su_park/backend/dto/responseBody/ApiResponseBody.java
@@ -1,5 +1,6 @@
 package park_su_park.backend.dto.responseBody;
 
+import jakarta.annotation.Nullable;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -9,13 +10,14 @@ import lombok.Getter;
 public class ApiResponseBody {
 
     private final String message;
+    @Nullable
     private final ApiResponseData data;
 
-    public static ApiResponseBody success(String message, ApiResponseData data) {
+    public static ApiResponseBody create(String message, ApiResponseData data) {
         return new ApiResponseBody(message, data);
     }
 
-    public static ApiResponseBody failure(String message) {
+    public static ApiResponseBody create(String message) {
         return new ApiResponseBody(message, null);
     }
 }

--- a/backend/src/main/java/park_su_park/backend/dto/responseBody/ValidationFailureData.java
+++ b/backend/src/main/java/park_su_park/backend/dto/responseBody/ValidationFailureData.java
@@ -1,0 +1,18 @@
+package park_su_park.backend.dto.responseBody;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.Map;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ValidationFailureData implements ApiResponseData {
+
+    private final Map<String, String> fieldErrors;
+
+    public static ValidationFailureData create(Map<String, String> errors) {
+        return new ValidationFailureData(errors);
+    }
+}

--- a/backend/src/main/java/park_su_park/backend/util/constant/ValidationMessage.java
+++ b/backend/src/main/java/park_su_park/backend/util/constant/ValidationMessage.java
@@ -1,0 +1,20 @@
+package park_su_park.backend.util.constant;
+
+public interface ValidationMessage {
+    String REQUIRED_FIELD_MESSAGE = "공백의 내용은 허용하지 않습니다.";
+
+    String NO_WHITESPACE_ALLOWED = "공백이 포함된 입력은 허용하지 않습니다.";
+
+    String DEFAULT_EMAIL_VALIDATION_FAILED_MESSAGE = "이메일 형식 검증 실패";
+    String EMAIL_FORMAT_MESSAGE = "이메일 형식이 유효하지 않습니다.";
+
+    String MAX_TITLE_SIZE_MESSAGE = "일정의 제목은 공백을 허용하지 않으며 30자 이내로 작성해주세요.";
+
+    String USERNAME_SIZE_MESSAGE = "사용자명은 5자에서 15자 이내로 작성해주세요.";
+
+    String DEFAULT_PASSWORD_VALIDATION_FAILED_MESSAGE = "비밀번호 형식 검증 실패";
+    String PASSWORD_SIZE_MESSAGE = "비밀번호는 8자에서 20자 이내로 작성해주세요.";
+    String PASSWORD_PATTER_MESSAGE = "비밀번호는 영문 대소문자와 숫자 그리고 특수문자를 반드시 하나 이상 조합하여 작성해주세요.";
+
+    String DEFAULT_USERNAME_VALIDATION_FAILED_MESSAGE = "사용자명 형식 검증 실패";
+}

--- a/backend/src/main/java/park_su_park/backend/util/constant/ValidationRegExp.java
+++ b/backend/src/main/java/park_su_park/backend/util/constant/ValidationRegExp.java
@@ -1,0 +1,6 @@
+package park_su_park.backend.util.constant;
+
+public interface ValidationRegExp {
+    String PASSWORD_REGEXP = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[^A-Za-z0-9_])[A-Za-z\\d[^A-Za-z0-9_]]+$";
+    String USERNAME_REGEXP = "^[^\\s]+$";
+}

--- a/backend/src/main/java/park_su_park/backend/util/validation/Content.java
+++ b/backend/src/main/java/park_su_park/backend/util/validation/Content.java
@@ -1,0 +1,19 @@
+package park_su_park.backend.util.validation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import jakarta.validation.constraints.NotBlank;
+import park_su_park.backend.util.constant.ValidationMessage;
+
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = {})
+@Target({ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+@NotBlank(message = ValidationMessage.REQUIRED_FIELD_MESSAGE)
+public @interface Content {
+    String message() default ValidationMessage.REQUIRED_FIELD_MESSAGE;
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/backend/src/main/java/park_su_park/backend/util/validation/EmailCustom.java
+++ b/backend/src/main/java/park_su_park/backend/util/validation/EmailCustom.java
@@ -1,0 +1,21 @@
+package park_su_park.backend.util.validation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import park_su_park.backend.util.constant.ValidationMessage;
+
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = {})
+@Target({ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+@Email(message = ValidationMessage.EMAIL_FORMAT_MESSAGE)
+@NotBlank(message = ValidationMessage.REQUIRED_FIELD_MESSAGE)
+public @interface EmailCustom {
+    String message() default ValidationMessage.DEFAULT_EMAIL_VALIDATION_FAILED_MESSAGE;
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/backend/src/main/java/park_su_park/backend/util/validation/Password.java
+++ b/backend/src/main/java/park_su_park/backend/util/validation/Password.java
@@ -5,6 +5,7 @@ import jakarta.validation.Payload;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import park_su_park.backend.util.constant.ValidationMessage;
+import park_su_park.backend.util.constant.ValidationRegExp;
 
 import java.lang.annotation.*;
 
@@ -13,7 +14,7 @@ import java.lang.annotation.*;
 @Target({ElementType.FIELD})
 @Retention(RetentionPolicy.RUNTIME)
 @Size(min = 8, max = 20, message = ValidationMessage.PASSWORD_SIZE_MESSAGE)
-@Pattern(regexp = ValidationMessage.PASSWORD_REGEXP, message = ValidationMessage.PASSWORD_PATTER_MESSAGE)
+@Pattern(regexp = ValidationRegExp.PASSWORD_REGEXP, message = ValidationMessage.PASSWORD_PATTER_MESSAGE)
 public @interface Password {
     String message() default ValidationMessage.DEFAULT_PASSWORD_VALIDATION_FAILED_MESSAGE;
     Class<?>[] groups() default {};

--- a/backend/src/main/java/park_su_park/backend/util/validation/Password.java
+++ b/backend/src/main/java/park_su_park/backend/util/validation/Password.java
@@ -1,0 +1,21 @@
+package park_su_park.backend.util.validation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import park_su_park.backend.util.constant.ValidationMessage;
+
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = {})
+@Target({ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+@Size(min = 8, max = 20, message = ValidationMessage.PASSWORD_SIZE_MESSAGE)
+@Pattern(regexp = ValidationMessage.PASSWORD_REGEXP, message = ValidationMessage.PASSWORD_PATTER_MESSAGE)
+public @interface Password {
+    String message() default ValidationMessage.DEFAULT_PASSWORD_VALIDATION_FAILED_MESSAGE;
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/backend/src/main/java/park_su_park/backend/util/validation/Title.java
+++ b/backend/src/main/java/park_su_park/backend/util/validation/Title.java
@@ -1,0 +1,19 @@
+package park_su_park.backend.util.validation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import org.hibernate.validator.constraints.Length;
+import park_su_park.backend.util.constant.ValidationMessage;
+
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = {})
+@Target({ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+@Length(min = 1, max = 30, message = ValidationMessage.MAX_TITLE_SIZE_MESSAGE)
+public @interface Title {
+    String message() default ValidationMessage.MAX_TITLE_SIZE_MESSAGE;
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/backend/src/main/java/park_su_park/backend/util/validation/Username.java
+++ b/backend/src/main/java/park_su_park/backend/util/validation/Username.java
@@ -1,0 +1,22 @@
+package park_su_park.backend.util.validation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import park_su_park.backend.util.constant.ValidationMessage;
+import park_su_park.backend.util.constant.ValidationRegExp;
+
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = {})
+@Target({ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+@Size(min = 5, max = 15, message = ValidationMessage.USERNAME_SIZE_MESSAGE)
+@Pattern(regexp = ValidationRegExp.USERNAME_REGEXP, message = ValidationMessage.NO_WHITESPACE_ALLOWED)
+public @interface Username {
+    String message() default ValidationMessage.DEFAULT_USERNAME_VALIDATION_FAILED_MESSAGE;
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/backend/src/main/java/park_su_park/backend/web/security/SecurityConfig.java
+++ b/backend/src/main/java/park_su_park/backend/web/security/SecurityConfig.java
@@ -1,0 +1,15 @@
+package park_su_park.backend.web.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import park_su_park.backend.web.security.encoder.BCryptPasswordEncoder;
+import park_su_park.backend.web.security.encoder.PasswordEncoder;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder(){
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/backend/src/main/java/park_su_park/backend/web/security/encoder/BCryptPasswordEncoder.java
+++ b/backend/src/main/java/park_su_park/backend/web/security/encoder/BCryptPasswordEncoder.java
@@ -1,0 +1,16 @@
+package park_su_park.backend.web.security.encoder;
+
+import at.favre.lib.crypto.bcrypt.BCrypt;
+
+public class BCryptPasswordEncoder implements PasswordEncoder{
+    @Override
+    public String encode(String rawPassword) {
+        return BCrypt.withDefaults().hashToString(BCrypt.MIN_COST, rawPassword.toCharArray());
+    }
+
+    @Override
+    public boolean match(String rawPassword, String encodedPassword) {
+        BCrypt.Result result = BCrypt.verifyer().verify(rawPassword.toCharArray(), encodedPassword);
+        return result.verified;
+    }
+}

--- a/backend/src/main/java/park_su_park/backend/web/security/encoder/PasswordEncoder.java
+++ b/backend/src/main/java/park_su_park/backend/web/security/encoder/PasswordEncoder.java
@@ -1,0 +1,7 @@
+package park_su_park.backend.web.security.encoder;
+
+public interface PasswordEncoder {
+    String encode(String rawPassword);
+
+    boolean match(String rawPassword, String encodedPassword);
+}


### PR DESCRIPTION
## 변경 사항
- request body의 데이터가 적절한 형식인지 검증하고 예외처리 하는 기능 추가
- PasswordEncoder 인터페이스 추가 및 BCrypt 를 사용하여 PasswordEncoder 구현체 추가
- 위의 변경사항을 반영한 api 명세서 수정
## 이슈 번호
Closes #51 
## 체크 리스트

- [x] 병합되는 브랜치를 한번 더 확인 해주세요!
- [x] 이슈 번호 연결을 하셨나요?
- [x] 담당자 설정을 하셨나요?
